### PR TITLE
Revert "Bump ndarray from 0.15.6 to 0.16.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
  "linfa 0.7.1 (git+https://github.com/rust-ml/linfa.git)",
  "linfa-clustering",
  "linfa-nn 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ndarray 0.16.1",
+ "ndarray 0.15.6",
  "object_store",
  "plotly",
  "serde",
@@ -3585,8 +3585,6 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
- "rayon",
- "serde",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ datafusion-common = "*"
 datafusion-expr = "*"
 linfa = { git = "https://github.com/rust-ml/linfa.git", version = "0.7.0", features = ["serde", "ndarray-linalg"] }
 linfa-clustering = { git = "https://github.com/rust-ml/linfa.git", version = "0.7.0", features = ["ndarray-linalg", "serde"] }
-ndarray = { version = "0.16.1", features = ["rayon", "serde"] }
+ndarray = { version = "0.15.6", features = ["rayon", "serde"] }
 linfa-nn = { version = "0.7.2", features = ["serde"] }
 plotly = { version = "0.12.1", features = ["kaleido", "ndarray"] }
 lindera = { version = "0.23.0", features = ["ipadic"], optional=true }


### PR DESCRIPTION
Reverts tmokazaki/gcprs#14 since linfa does not support for now.